### PR TITLE
Improve test_pana dependency handling

### DIFF
--- a/test_pana.py
+++ b/test_pana.py
@@ -1,12 +1,30 @@
 #!/usr/bin/env python3
 """
 Simple test script for pyPANA implementation
-Tests basic message creation and parsing
+Tests basic message creation and parsing.
+
+Requirements: cryptography, pyOpenSSL
+Install with: ``pip install -r requirements.txt``
 """
 
 import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+missing = []
+try:
+    import cryptography
+except ImportError:
+    missing.append("cryptography")
+try:
+    from OpenSSL import crypto  # noqa: F401
+except ImportError:
+    missing.append("pyOpenSSL")
+
+if missing:
+    print("Skipping tests due to missing dependencies: {}".format(", ".join(missing)))
+    print("Install required packages with: pip install -r requirements.txt")
+    sys.exit(0)
 
 from pyPANA import (
     PANAMessage, AVP, CryptoContext,


### PR DESCRIPTION
## Summary
- check for cryptography and pyOpenSSL before running tests
- skip gracefully with instructions if missing

## Testing
- `python3 test_basic.py`
- `python3 test_pana.py`

------
https://chatgpt.com/codex/tasks/task_e_6850c90c24d0832b8e1b41da3922ab6f